### PR TITLE
 Add python 3.14 and Django 5.2 and 6.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [ push, pull_request ]
+on: [pull_request]
 
 jobs:
   pre-commit:
@@ -12,12 +12,12 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install pre-commit~=4.0.0
+          python3 -m pip install pre-commit~=4.5.0
           python3 -m pre_commit install
 
       - name: Run pre-commit
@@ -30,23 +30,81 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - '3.8'
-        - '3.9'
-        - '3.10'
-        - '3.11'
-        - '3.12'
-        - '3.13'
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
         django-version:
-        - '4.2'
-        - '5.0'
-        - '5.1'
-        - 'main'
+          - "4.2"
+          - "5.0"
+          - "5.1"
+          - "5.2"
+          - "6.0"
+          - "main"
         include:
           # https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
-          - python-version: '3.8'
-            django-version: '4.2'
-          - python-version: '3.9'
-            django-version: '4.2'
+
+          # ───── Django 4.2 (LTS) ─────
+          - python-version: "3.8"
+            django-version: "4.2"
+          - python-version: "3.9"
+            django-version: "4.2"
+          - python-version: "3.10"
+            django-version: "4.2"
+          - python-version: "3.11"
+            django-version: "4.2"
+          - python-version: "3.12"
+            django-version: "4.2"
+
+          # ───── Django 5.0 ─────
+          - python-version: "3.10"
+            django-version: "5.0"
+          - python-version: "3.11"
+            django-version: "5.0"
+          - python-version: "3.12"
+            django-version: "5.0"
+
+          # ───── Django 5.1 ─────
+          - python-version: "3.10"
+            django-version: "5.1"
+          - python-version: "3.11"
+            django-version: "5.1"
+          - python-version: "3.12"
+            django-version: "5.1"
+          - python-version: "3.13"
+            django-version: "5.1"
+
+          # ───── Django 5.2 ─────
+          - python-version: "3.10"
+            django-version: "5.2"
+          - python-version: "3.11"
+            django-version: "5.2"
+          - python-version: "3.12"
+            django-version: "5.2"
+          - python-version: "3.13"
+            django-version: "5.2"
+          - python-version: "3.14"
+            django-version: "5.2"
+
+          # ───── Django 6.0 ─────
+          - python-version: "3.12"
+            django-version: "6.0"
+          - python-version: "3.13"
+            django-version: "6.0"
+          - python-version: "3.14"
+            django-version: "6.0"
+
+          # ───── Django main ─────
+          - python-version: "3.12"
+            django-version: "main"
+          - python-version: "3.13"
+            django-version: "main"
+          - python-version: "3.14"
+            django-version: "main"
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -58,25 +116,25 @@ jobs:
 
       - name: Get pip cache dir
         id: pip-cache
-        run: |
-          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
-      - name: Cache
+      - name: Cache pip
         uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
-          key:
-            ${{ matrix.python-version }}-v1-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/tox.ini') }}
+          key: >
+            ${{ matrix.python-version }}-pip-
+            ${{ hashFiles('**/pyproject.toml') }}-
+            ${{ hashFiles('**/tox.ini') }}
           restore-keys: |
-            ${{ matrix.python-version }}-v1-
+            ${{ matrix.python-version }}-pip-
 
-      - name: Install Python dependencies
+      - name: Install tox
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade tox tox-gh-actions
 
-      - name: Tox tests
-        run: |
-          tox -v
+      - name: Run tox
+        run: tox -v
         env:
           DJANGO: ${{ matrix.django-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install dependencies
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 default_language_version:
-  python: python3.12
+  python: python3.13
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v5.0.0"
+    rev: "v6.0.0"
     hooks:
       - id: check-added-large-files
         args: [ "--maxkb=1024" ]
@@ -16,28 +16,30 @@ repos:
       - id: detect-private-key
       - id: end-of-file-fixer
       - id: fix-byte-order-marker
-      - id: fix-encoding-pragma
-        args: [ "--remove" ]
       - id: mixed-line-ending
       - id: trailing-whitespace
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.21.2
+    hooks:
+    -   id: pyupgrade
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.9.6
+    rev: v0.14.10
     hooks:
       - id: ruff
         args:
           - --fix
       - id: ruff-format
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "v2.5.0"
+    rev: "v2.11.1"
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/pycqa/bandit
-    rev: "1.8.2"
+    rev: "1.9.2"
     hooks:
       - id: bandit
         additional_dependencies: [ "bandit[toml]" ]
         args: [ "--configfile", "pyproject.toml", "--quiet", "--recursive" ]
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.23.3
+    rev: v8.30.0
     hooks:
       - id: gitleaks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "django-never-cache"
-version = "0.1.1"
+version = "0.1.2"
 description = "A Django app that provides a suite of utilities to disable caching in template views."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -27,6 +27,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Internet :: WWW/HTTP",
   "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
 ]
@@ -37,7 +38,7 @@ dependencies = [
 urls.Homepage = "https://github.com/trottomv/django-never-cache"
 
 [tool.ruff]
-target-version = "py312"
+target-version = "py313"
 
 format.docstring-code-format = true
 lint.select = [
@@ -61,7 +62,7 @@ enable_error_code = [
   "truthy-bool",
 ]
 ignore_missing_imports = true
-python_version = "3.12"
+python_version = "3.13"
 
 [tool.bandit]
 exclude_dirs = [

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,10 @@ envlist =
     py{38,39,310,311,312}-dj42,
     py{310,311,312}-dj50,
     py{310,311,312,313}-dj51,
-    py{312,313}-djmain,
+    py{310,311,312,313,314}-dj52,
+    py{312,313,314}-dj60,
+    py{312,313,314,315}-djmain,
+skip_missing_interpreters = true
 
 [gh-actions]
 python =
@@ -13,17 +16,22 @@ python =
     3.11: py311
     3.12: py312
     3.13: py313
+    3.14: py314
+    3.15: py315
 
 [gh-actions:env]
 DJANGO =
     4.2: dj42
     5.0: dj50
     5.1: dj51
+    5.2: dj52
+    6.0: dj60
     main: djmain
 
 [testenv]
 commands =
     pytest {posargs}
+download = true
 setenv =
     DJANGO_SETTINGS_MODULE = tests.settings
     PYTHONPATH = {toxinidir}
@@ -32,10 +40,11 @@ deps =
     dj42: Django>=4.2,<4.3
     dj50: Django>=5.0,<5.1
     dj51: Django>=5.1,<5.2
+    dj52: Django>=5.2,<6.0
+    dj60: Django>=6.0
     djmain: https://github.com/django/django/archive/main.tar.gz
     pytest
     pytest-cov
     pytest-django
-    pytz; python_version < '3.9'
 passenv =
     PYTEST_ADDOPTS


### PR DESCRIPTION
- Extend CI test matrix for Django 5.2, 6.0
- Upgrade pre-commit hooks
- Update pyproject.toml with Python 3.14 support
- Refine tox configurations for new environments